### PR TITLE
Fix issue #8: Login As does not show the right theme

### DIFF
--- a/classes/profiletheme.php
+++ b/classes/profiletheme.php
@@ -59,6 +59,10 @@ class profiletheme extends profilefields {
         global $USER, $SESSION;
 
         if ($event && $event->userid != $USER->id) {
+            echo "<pre>";
+            var_dump($event);
+            echo "</pre>";
+            echo "$event->userid vs $USER->id";exit;
             return; // Only sets the theme for the current user.
         }
 
@@ -66,6 +70,23 @@ class profiletheme extends profilefields {
             $SESSION->theme = $theme;
         }
     }
+    
+    /**
+     * Called after the user has logged in as another user, to apply any mappings and set the session theme
+     * @param \core\event\base|null $event
+     */
+    public static function set_theme_from_profile_loginas(\core\event\base $event = null) {
+        global $USER, $SESSION;
+
+        if ($event && $event->relateduserid != $USER->id) {
+            return; // Only sets the theme for the current user.
+        }
+
+        if ($theme = self::get_mapped_value($USER->id)) {
+            $SESSION->theme = $theme;
+        }
+    }
+
 
     /**
      * Load a list of possible values that fields can be mapped onto.

--- a/classes/profiletheme.php
+++ b/classes/profiletheme.php
@@ -66,6 +66,22 @@ class profiletheme extends profilefields {
             $SESSION->theme = $theme;
         }
     }
+    
+    /**
+     * Called after the user has logged in as another user, to apply any mappings and set the session theme
+     * @param \core\event\base|null $event
+     */
+    public static function set_theme_from_profile_loginas(\core\event\base $event = null) {
+        global $USER, $SESSION;
+
+        if ($event && $event->relateduserid != $USER->id) {
+            return; // Only sets the theme for the current user.
+        }
+
+        if ($theme = self::get_mapped_value($USER->id)) {
+            $SESSION->theme = $theme;
+        }
+    }
 
     /**
      * Load a list of possible values that fields can be mapped onto.

--- a/db/events.php
+++ b/db/events.php
@@ -28,5 +28,9 @@ $observers = [
     [
         'eventname' => '\core\event\user_loggedin',
         'callback' => '\local_profiletheme\profiletheme::set_theme_from_profile'
+    ],
+    [
+        'eventname' => '\core\event\user_loggedinas',
+        'callback' => '\local_profiletheme\profiletheme::set_theme_from_profile_loginas'
     ]
 ];

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'local_profiletheme';
-$plugin->version = 2017112300;
+$plugin->version = 2018010801;
 $plugin->release = 'v3.3-r1';
 $plugin->requires = 2017051500;
 $plugin->maturity = MATURITY_STABLE;

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'local_profiletheme';
-$plugin->version = 2017121200;
+$plugin->version = 2018010800;
 $plugin->release = 'v3.4-r1';
 $plugin->requires = 2017111300;
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
Hi,

I added another event observer for the user:loggedinas event and created a new function that compares $event->relatedusedid to $USER->id instead of the check in the original function that compares $event->userid to $USER->id. Works and tested in Moodle 3.3.